### PR TITLE
Edit Miami-Dade county

### DIFF
--- a/counties.json
+++ b/counties.json
@@ -344,7 +344,7 @@
       "Clay",
       "Collier",
       "Columbia",
-      "Dade",
+      "Miami-Dade",
       "De Soto",
       "Dixie",
       "Duval",


### PR DESCRIPTION
There is no Dade county. The name is Miami-Dade.